### PR TITLE
tweak table display and header doc id input responsive sizes

### DIFF
--- a/src/DocumentList.tsx
+++ b/src/DocumentList.tsx
@@ -5,6 +5,7 @@ import {
   Table,
   Tbody,
   Td,
+  Text,
   Th,
   Thead,
   Tr,
@@ -47,13 +48,7 @@ const DocumentList = (props: DocListProps) => {
   if (error) return <strong>Error: {JSON.stringify(error)}</strong>
 
   return (
-    <Flex
-      justifyContent="space-between"
-      flexDir="column"
-      alignItems="center"
-      px={6}
-      py={6}
-    >
+    <Box px={{ base: 0, md: 6 }}>
       {/* <HStack fontSize="sm" divider={<StackDivider />}>
         <Text onClick={handlePrev}>
           <Link href="#">Prev</Link>
@@ -77,18 +72,17 @@ const DocumentList = (props: DocListProps) => {
               const { id, timestamp } = doc.data()
               return (
                 <Tr key={id}>
-                  <Td>
+                  <Td maxWidth={{ base: '300px' }}>
                     <Link
                       as={ReachLink}
                       to={`/document/${id}`}
-                      isTruncated
                       textDecoration="underline"
                     >
-                      {id}
+                      <Text isTruncated>{id}</Text>
                     </Link>
                   </Td>
                   <Td>
-                    {moment(timestamp).format('h:mm:ssA, MMMM Do YYYY') || '—'}
+                    {moment(timestamp).format("h:mm:ssA, MMM D 'YY") || '—'}
                   </Td>
                 </Tr>
               )
@@ -96,7 +90,7 @@ const DocumentList = (props: DocListProps) => {
           </Tbody>
         </Table>
       </Box>
-    </Flex>
+    </Box>
   )
 }
 

--- a/src/components/DocInputForm.tsx
+++ b/src/components/DocInputForm.tsx
@@ -22,17 +22,18 @@ const DocInputForm: React.SFC<DocInputFormProps> = ({
     <Box>
       <Center>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Input
-            name="docId"
-            type="text"
-            ref={register()}
-            size="lg"
-            width="66ch"
-            mb={3}
-            placeholder="eg k3y52l7qbv1frxjdr9qpn9ldvbxb0jg4eig7wtjkdu6gk84vyazw9j4txf4o6d2io"
-          />
+          <Box width={{ base: '550px', md: '70ch' }}>
+            <Input
+              name="docId"
+              type="text"
+              ref={register()}
+              size="lg"
+              mb={3}
+              placeholder="eg k3y52l7qbv1frxjdr9qpn9ldvbxb0jg4eig7wtjkdu6gk84vyazw9j4txf4o6d2io"
+            />
+          </Box>
           {errors.docId && errors.docId.message}
-          <Center>
+          <Center width="100%">
             <Flex alignItems="center" mb={mb} wrap="wrap">
               <Button
                 type="submit"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66292936/107631191-817a5080-6c5c-11eb-8769-b733e2ab7a5d.png)

- truncates document id, reduces horizontal padding on mobile
- sets small width on doc id input on mobile