### PR TITLE
revert to any type

### DIFF
--- a/src/hooks/useCommit.tsx
+++ b/src/hooks/useCommit.tsx
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query'
 import DocID from "@ceramicnetwork/docid";
 import { ceramic } from '../App'
 
-const getCommitById = async (docId: DocID) => {
+const getCommitById = async (docId: any) => {
   const doc = await ceramic.loadDocument(docId).then((res) => res)
   return doc
 }

--- a/src/hooks/useDoc.tsx
+++ b/src/hooks/useDoc.tsx
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query'
 import DocID from "@ceramicnetwork/docid";
 import { ceramic } from '../App'
 
-const getDocById = async (docId: DocID) => {
+const getDocById = async (docId: any) => {
   const doc = await ceramic.loadDocument(docId).then((res) => res)
   return doc
 }


### PR DESCRIPTION
Not sure what's going on here but the DocID type is giving me all sorts of grief in the document hooks.

I've just reverted to `any` for the sake of moving forward but if you can see what's up feel free to jump in and do a proper fix.