### PR TITLE
updates for mainnet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ export interface DocumentInterface {
   timestamp?: string
 }
 
-const API_URL = 'https://gateway-clay.ceramic.network'
+const API_URL = 'https://gateway.ceramic.network'
 export const ceramic = new CeramicClient(API_URL)
 
 interface AppProps extends RouteComponentProps {

--- a/src/DocumentList.tsx
+++ b/src/DocumentList.tsx
@@ -32,7 +32,7 @@ const DocumentList = (props: DocListProps) => {
     isEnd,
     getPrev,
     getNext,
-  } = usePagination(db.collection('documents').orderBy('timestamp', 'desc'), {
+  } = usePagination(db.collection('streams').orderBy('timestamp', 'desc'), {
     limit: 20,
   })
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,10 +18,13 @@ const Footer = () => {
           href="https://twitter.com/tannedoaksprout"
         >
           oaksprout
-        </Link>{' '}
-        &{' '}
+        </Link>
+        ,{' '}
         <Link textDecoration="underline" href="https://github.com/isidorosp">
           isidorosp
+        </Link>{' '}&{' '}
+        <Link textDecoration="underline" href="https://github.com/emersonmacro">
+          emersonmacro
         </Link>{' '}
         in support of{' '}
         <Link

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Box,
   Center,
   Divider,
@@ -40,6 +41,7 @@ const Header: React.FC<HeaderProps> = ({ schema, setLens, docId }) => {
         <Center h="100%">
           <Divider orientation="vertical" mx={{ base: 0, lg: 3 }} />
         </Center>
+        <Badge colorScheme="orange" display={{base: 'none', lg: 'inherit'}}>Mainnet</Badge>
         {/* <Box mx="left">
           <LensSection schema={schema} setLens={setLens} />
         </Box> */}

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,23 +1,17 @@
-import React from 'react'
 import {
-  chakra,
   Box,
-  useColorModeValue,
-  Flex,
-  SimpleGrid,
-  GridItem,
-  VisuallyHidden,
-  Input,
-  Button,
-  Stack,
-  Icon,
   Center,
+  chakra,
+  Flex,
+  Icon,
+  useColorModeValue,
 } from '@chakra-ui/react'
+import React from 'react'
 import DocInputForm from './DocInputForm'
 import Logo from './Logo'
 
 const Hero = () => {
-  const Feature = props => (
+  const Feature = (props) => (
     <Flex alignItems="center" color={useColorModeValue(null, 'white')}>
       <Icon
         boxSize={4}
@@ -55,14 +49,28 @@ const Hero = () => {
           The Portal to a New Web
         </chakra.h1>
         <chakra.p
-          mb={6}
+          mb={3}
           fontSize={{ base: 'lg', md: 'xl' }}
           color="gray.500"
           lineHeight="base"
         >
-          Browse the Ceramic network and{' '}
-          <br/>
+          Browse the Ceramic network and <br />
           experience the emergence of a new interaction paradigm.
+        </chakra.p>
+        <chakra.p
+          mb={6}
+          fontSize={{ base: 'lg', md: 'xl' }}
+          color="gray.500"
+          lineHeight="base"
+          fontWeight="bold"
+        >
+          <chakra.span
+            bgGradient="linear(to-r, orange.500, orange.300)"
+            bgClip="text"
+          >
+            Now live on Ceramic mainnet!
+          </chakra.span>{" "}
+           🤩 🎉
         </chakra.p>
         <Center>
           <DocInputForm baseBorder={1} />


### PR DESCRIPTION
- switches over gateway to mainnet gateway
- switches db read to read from 'streams' (mainnet) rather than 'documents' (testnet)
- adds indicator to tell ppl they're on mainnet – homepage hero and header

In the future it would be nice to be able to toggle between testnet and mainnet obviously. But in the interests of getting this thing live, and also not burning up big bucks on firestore, I reckon just mainnet is fine for now.